### PR TITLE
(chore)experiment-manifests: adds prerequisites and sample engine definition for pod-delete

### DIFF
--- a/test-data/litmus/litmus-operator-v1.8.1.yaml
+++ b/test-data/litmus/litmus-operator-v1.8.1.yaml
@@ -1,0 +1,511 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litmus
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: litmus
+  namespace: litmus
+  labels:
+    name: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: litmus
+  labels:
+    name: litmus
+rules:
+- apiGroups: ["","apps","batch","litmuschaos.io","apps.openshift.io"]
+  resources: ["pods","jobs","deployments","replicationcontrollers","daemonsets","replicasets","statefulsets","deploymentconfigs","events","configmaps","services","secrets","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["get","create","list","delete","update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: litmus
+  labels:
+    name: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: litmus
+subjects:
+- kind: ServiceAccount
+  name: litmus
+  namespace: litmus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaos-operator-ce
+  namespace: litmus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: chaos-operator
+  template:
+    metadata:
+      labels:
+        name: chaos-operator
+    spec:
+      serviceAccountName: litmus
+      containers:
+        - name: chaos-operator
+          image: litmuschaos/chaos-operator:1.8.1
+          command:
+          - chaos-operator
+          imagePullPolicy: Always
+          env:
+            - name: CHAOS_RUNNER_IMAGE
+              value: "litmuschaos/chaos-runner:1.8.1"
+            - name: WATCH_NAMESPACE
+              value: ""
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "chaos-operator"
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosengines.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosEngine
+    listKind: ChaosEngineList
+    plural: chaosengines
+    singular: chaosengine
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+            monitoring:
+              type: boolean
+            jobCleanUpPolicy:
+              type: string
+              pattern: ^(delete|retain)$
+              # alternate ways to do this in case of complex pattern matches
+              #oneOf:
+              #  - pattern: '^delete$'
+              #  - pattern: '^retain$'
+            annotationCheck:
+              type: string
+              pattern: ^(true|false)$
+            appinfo:
+              type: object
+              properties:
+                appkind:
+                  type: string
+                  pattern: ^(deployment|statefulset|daemonset|deploymentconfig)$
+                applabel:
+                  pattern: ([a-z0-9A-Z_\.-/]+)=([a-z0-9A-Z_\.-/_]+)
+                  type: string
+                appns:
+                  type: string
+            auxiliaryAppInfo:
+              type: string
+            engineState:
+              type: string
+              pattern: ^(active|stop|initialized|stopped)$
+            chaosServiceAccount:
+              type: string
+            components:
+              type: object
+              properties:
+                runner:
+                  type: object
+                  properties:
+                    image:
+                      type: string
+                    type:
+                      type: string
+                      pattern: ^(go)$
+                    runnerannotation:
+                      type: object
+                      additionalProperties:
+                        type: string
+                        properties:
+                          key:
+                            type: string
+                            minLength: 1
+                            allowEmptyValue: false
+                          value:
+                            type: string
+                            minLength: 1
+                            allowEmptyValue: false
+            experiments:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  spec:
+                    type: object
+                    properties:
+                      k8sProbe:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            inputs:
+                              type: object
+                              properties:
+                                command:
+                                  type: object
+                                  properties:
+                                    group:
+                                      type: string
+                                    version:
+                                      type: string
+                                    resource:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                    fieldSelector:
+                                      type: string
+                                    labelSelector:
+                                      type: string
+                                expectedResult:
+                                  type: string
+                            runProperties:
+                              type: object
+                              properties:
+                                probeTimeout:
+                                  type: integer
+                                interval:
+                                  type: integer
+                                retry: 
+                                  type: integer
+                            mode:
+                              type: string
+                      cmdProbe:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            inputs:
+                              type: object
+                              properties:
+                                command:
+                                  type: string
+                                expectedResult:
+                                  type: string
+                                source:
+                                  type: string
+                            runProperties:
+                              type: object
+                              properties:
+                                probeTimeout:
+                                  type: integer
+                                interval:
+                                  type: integer
+                                retry: 
+                                  type: integer
+                            mode:
+                              type: string
+                      httpProbe:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            inputs:
+                              type: object
+                              properties:
+                                url:
+                                  type: string
+                                expectedResponseCode:
+                                  type: string
+                            runProperties:
+                              type: object
+                              properties:
+                                probeTimeout:
+                                  type: integer
+                                interval:
+                                  type: integer
+                                retry: 
+                                  type: integer
+                            mode:
+                              type: string
+                      components:
+                        type: object
+                        properties:
+                          statusCheckTimeouts:
+                            type: object
+                            properties:
+                              delay:
+                                type: integer
+                              timeout:
+                                type: integer
+                          nodeSelector:
+                            type: object
+                            minLength: 1
+                          experimentImage:
+                            type: string
+                          env:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                          configMaps:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                mountPath:
+                                  type: string
+                          secrets:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                mountPath:
+                                  type: string
+                          experimentannotation:
+                            type: object
+                            additionalProperties:
+                              type: string
+                              properties:
+                                key:
+                                  type: string
+                                  minLength: 1
+                                  allowEmptyValue: false
+                                value:
+                                  type: string
+                                  minLength: 1
+                                  allowEmptyValue: false
+
+
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosexperiments.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosExperiment
+    listKind: ChaosExperimentList
+    plural: chaosexperiments
+    singular: chaosexperiment
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+          properties:
+            definition:
+              type: object
+              properties:
+                args:
+                  type: array
+                  items:
+                    type: string
+                command:
+                  type: array
+                  items:
+                    type: string
+                env:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                image:
+                  type: string
+                labels:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                scope:
+                  type: string
+                  pattern: ^(Namespaced|Cluster)$
+                permissions:
+                  type: array
+                  items:
+                    type: object
+                    minProperties: 3
+                    required:
+                      - apiGroups
+                      - resources
+                      - verbs
+                    properties:
+                      apiGroups:
+                        type: array
+                        items:
+                          type: string
+                      resources:
+                        type: array
+                        items:
+                          type: string
+                      verbs:
+                        type: array
+                        items:
+                          type: string
+                      resourceNames:
+                        type: array
+                        items:
+                          type: string
+                      nonResourceURLs:
+                        type: array
+                        items:
+                          type: string
+                configmaps:
+                  type: array
+                  items:
+                    type: object
+                    minProperties: 2
+                    properties:
+                      name:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      mountPath:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                secrets:
+                  type: array
+                  items:
+                    type: object
+                    minProperties: 2
+                    properties:
+                      name:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      mountPath:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                hostFileVolumes:
+                  type: array
+                  items:
+                    type: object
+                    minProperties: 3
+                    properties:
+                      name:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      mountPath:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                      nodePath:
+                        type: string
+                        allowEmptyValue: false
+                        minLength: 1
+                securityContext:
+                  type: object
+                hostPID:
+                  type: boolean
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: chaosresults.litmuschaos.io
+spec:
+  group: litmuschaos.io
+  names:
+    kind: ChaosResult
+    listKind: ChaosResultList
+    plural: chaosresults
+    singular: chaosresult
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/test-data/litmus/pod-delete-ChaosEngine-Trigger-CR.yaml
+++ b/test-data/litmus/pod-delete-ChaosEngine-Trigger-CR.yaml
@@ -1,0 +1,30 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: carts-chaos
+  namespace: litmus-chaos
+spec:
+  appinfo:
+    applabel: 'app=carts'
+    appkind: 'deployment'
+  annotationCheck: 'false'
+  engineState: 'active'
+  chaosServiceAccount: pod-delete-sa
+  monitoring: true
+  jobCleanUpPolicy: 'retain'
+  experiments:
+    - name: pod-delete
+      spec:
+        components:
+          env:
+            # set chaos duration (in sec) as desired
+            - name: TOTAL_CHAOS_DURATION
+              value: '10'
+
+            # set chaos interval (in sec) as desired
+            - name: CHAOS_INTERVAL
+              value: '10'
+              
+            # pod failures without '--force' & default terminationGracePeriodSeconds
+            - name: FORCE
+              value: 'false'

--- a/test-data/litmus/pod-delete-ChaosExperiment-CR.yaml
+++ b/test-data/litmus/pod-delete-ChaosExperiment-CR.yaml
@@ -1,0 +1,71 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: pod-delete
+  namespace: litmus-chaos
+spec:
+  definition:
+    scope: Namespaced
+    permissions:
+      - apiGroups:
+          - ""
+          - "apps"
+          - "batch"
+          - "litmuschaos.io"
+        resources:
+          - "deployments"
+          - "jobs"
+          - "pods"
+          - "pods/log"
+          - "events"
+          - "configmaps"
+          - "chaosengines"
+          - "chaosexperiments"
+          - "chaosresults"
+        verbs:
+          - "create"
+          - "list"
+          - "get"
+          - "patch"
+          - "update"
+          - "delete"
+      - apiGroups:
+          - ""
+        resources: 
+          - "nodes"
+        verbs:
+          - "get"
+          - "list"
+    image: "litmuschaos/go-runner:1.8.1"
+    imagePullPolicy: Always
+    args:
+    - -c
+    - ./experiments/pod-delete
+    command:
+    - /bin/bash
+    env:
+
+    - name: TOTAL_CHAOS_DURATION
+      value: '15'
+
+    # Period to wait before and after injection of chaos in sec
+    - name: RAMP_TIME
+      value: ''
+
+    - name: FORCE
+      value: 'true'
+
+    - name: CHAOS_INTERVAL
+      value: '5'
+
+    ## percentage of total pods to target
+    - name: PODS_AFFECTED_PERC
+      value: ''
+
+    - name: LIB
+      value: 'litmus'    
+
+    - name: TARGET_POD
+      value: ''
+    labels:
+      name: pod-delete

--- a/test-data/litmus/pod-delete-rbac.yaml
+++ b/test-data/litmus/pod-delete-rbac.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-delete-sa
+  namespace: litmus-chaos
+  labels:
+    name: pod-delete-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: pod-delete-sa
+  namespace: litmus-chaos
+  labels:
+    name: pod-delete-sa
+rules:
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: ["pods","deployments","pods/log","events","jobs","chaosengines","chaosexperiments","chaosresults"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: pod-delete-sa
+  namespace: litmus-chaos
+  labels:
+    name: pod-delete-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-delete-sa
+  namespace: litmus-chaos
+

--- a/test-data/setup.sh
+++ b/test-data/setup.sh
@@ -25,6 +25,22 @@ keptn add-resource --project=litmus --stage=chaos --service=carts --resource=slo
 
 keptn configure monitoring prometheus --project=litmus --service=carts
 
+# Litmus PreReq Begins!! 
+
+## install litmus operator & chaos CRDs 
+
+kubectl apply -f litmus/litmus-operator-v1.8.1.yaml
+
+## pull the chaos experiment CR (static) 
+
+kubectl apply -f litmus/pod-delete-ChaosExperiment-CR.yaml 
+
+## pull the chaos experiment RBAC (static) 
+
+kubectl apply -f litmus/pod-delete-rbac.yaml 
+
+# Litmus PreReq End!! 
+
 ## now we also have to add the chaos tests - ATTENTION right now this file is empty!
 keptn add-resource --project=litmus --stage=chaos --service=carts --resource=litmus/experiment.yaml --resourceUri=litmus/experiment.yaml
 


### PR DESCRIPTION
- Initial set of chaos manifests & changes to setup.sh steps 

Signed-off-by: ksatchit <karthik.s@mayadata.io>