### PR TITLE
Fixed replicaCount in helm-chart

### DIFF
--- a/test-data/helloservice/helm/templates/deployment.yaml
+++ b/test-data/helloservice/helm/templates/deployment.yaml
@@ -7,6 +7,7 @@ spec:
   selector:
     matchLabels:
       app: helloservice
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
@@ -15,7 +16,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: server
-        image: {{ .Values.image}}
+        image: {{ .Values.image }}
         imagePullPolicy: Always
         ports:
         - containerPort: 9000
@@ -26,6 +27,6 @@ spec:
           httpGet:
             path: /
             port: 9000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 15


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

During testing I noticed that the helm-chart used does not use replicaCount.

Also, the container seems to start quite quickly, but due to the lifenessprobe set to 60 seconds, it always took at least 60 seconds for the initial check to start. I've reduced this to ~10~ 30 seconds.